### PR TITLE
fix: use correct type for hidden in blueprints

### DIFF
--- a/stubs/blueprint.stub
+++ b/stubs/blueprint.stub
@@ -26,7 +26,7 @@ class {{ class }} extends Blueprint
     /**
      * Hide the blueprint from the blueprint dropdown.
      *
-     * @var string
+     * @var bool
      */
     public $hidden = false;
 


### PR DESCRIPTION
We use PHPStan for analysis and this is one that pop-ups regularly.
Might be easier to fix it in the source :)