### PR TITLE
Check for entries in the collection instead of always true check

### DIFF
--- a/src/Http/Controllers/NavigationController.php
+++ b/src/Http/Controllers/NavigationController.php
@@ -11,7 +11,7 @@ class NavigationController extends StatamicNavigationController
     {
         $navBlueprint = BlueprintRepository::findBlueprintInNamespace('navigation', $navHandle);
 
-        if ($navBlueprint) {
+        if ($navBlueprint->count()) {
             $blueprintPath = BlueprintRepository::findBlueprintPath('navigation', $navHandle);
 
             return view('statamic-builder::not-editable', [

--- a/src/Http/Controllers/NavigationController.php
+++ b/src/Http/Controllers/NavigationController.php
@@ -11,7 +11,7 @@ class NavigationController extends StatamicNavigationController
     {
         $navBlueprint = BlueprintRepository::findBlueprintInNamespace('navigation', $navHandle);
 
-        if ($navBlueprint->count()) {
+        if ($navBlueprint->isNotEmpty()) {
             $blueprintPath = BlueprintRepository::findBlueprintPath('navigation', $navHandle);
 
             return view('statamic-builder::not-editable', [


### PR DESCRIPTION
As `BlueprintRepository::findBlueprintInNamespace('navigation', $navHandle);` returns a Collection, even when empty this will always be true. By calling `->count()` we get a realistic check.