### PR TITLE
Allow routes to be array when using multisite

### DIFF
--- a/src/BaseCollection.php
+++ b/src/BaseCollection.php
@@ -10,7 +10,7 @@ abstract class BaseCollection
 
     abstract public static function handle(): string;
 
-    abstract public function route(): ?string;
+    abstract public function route(): null|string|array;
 
     abstract public function slugs(): bool;
 

--- a/stubs/Collection.stub
+++ b/stubs/Collection.stub
@@ -49,10 +49,11 @@ class {{ class }} extends BaseCollection
      * Return the route for the collection
      *
      * Example: return '/blog/{slug}';
+     * Example: return ['default' => '/blog/{slug}'];
      *
      * Docs: https://statamic.dev/collections#routing
      */
-    public function route(): ?string
+    public function route(): ?null|string|array
     {
         return null;
     }


### PR DESCRIPTION
When using a multisite, in Statamic you are able to set a route for every site. This will be done via array. This way it works for one site, but also multisite.