### PR TITLE
Ability to hide collections from CP

### DIFF
--- a/src/BaseCollection.php
+++ b/src/BaseCollection.php
@@ -54,6 +54,11 @@ abstract class BaseCollection
 
     abstract public function pastDateBehavior(): ?string;
 
+    public function visible(): bool
+    {
+        return true;
+    }
+
     public function register()
     {
         $collection = StatamicCollection::make($this->handle())

--- a/src/Repositories/CollectionRepository.php
+++ b/src/Repositories/CollectionRepository.php
@@ -49,10 +49,10 @@ class CollectionRepository extends StatamicCollectionRepository
     public function all(): IlluminateCollection
     {
         $keys = $this->store->paths()->keys();
-        
+
         // add custom collections
-        $keys = $this->collections->keys()->filter(fn($collection) => $this->getCollectionByHandle($collection)->visible())->merge($keys);
-        
+        $keys = $this->collections->keys()->filter(fn ($collection) => $this->getCollectionByHandle($collection)->visible())->merge($keys);
+
         return $this->store->getItems($keys, $this->collections);
     }
 

--- a/src/Repositories/CollectionRepository.php
+++ b/src/Repositories/CollectionRepository.php
@@ -49,10 +49,10 @@ class CollectionRepository extends StatamicCollectionRepository
     public function all(): IlluminateCollection
     {
         $keys = $this->store->paths()->keys();
-
+        
         // add custom collections
-        $keys = $this->collections->keys()->merge($keys);
-
+        $keys = $this->collections->keys()->filter(fn($collection) => $this->getCollectionByHandle($collection)->visible())->merge($keys);
+        
         return $this->store->getItems($keys, $this->collections);
     }
 


### PR DESCRIPTION
In https://github.com/rapidez/statamic/pull/80/files we're using a kind of custom way of saving content via runway without actually adding columns to the database of the runway resource. We save the data in collection entries. But we don't want them to be visible/edited through the CP. Statamic currenty has no way of hiding collections from the CP (https://github.com/statamic/ideas/issues/259#issuecomment-2454785527). This way we CAN hide them and if you don't want to hide the collections you can just leave it as is.

Might be cool to add this :) What do you think? @tdwesten  