### PR TITLE
Fix paths to stub files in console commands

### DIFF
--- a/src/Console/MakeCollectionCommand.php
+++ b/src/Console/MakeCollectionCommand.php
@@ -26,7 +26,7 @@ class MakeCollectionCommand extends BaseGeneratorCommand
      */
     protected function getStub()
     {
-        return __DIR__.'/../../stubs/collection.stub';
+        return __DIR__.'/../../stubs/Collection.stub';
     }
 
     /**

--- a/src/Console/MakeFieldsetCommand.php
+++ b/src/Console/MakeFieldsetCommand.php
@@ -26,7 +26,7 @@ class MakeFieldsetCommand extends BaseGeneratorCommand
      */
     protected function getStub()
     {
-        return __DIR__.'/../../stubs/fieldset.stub';
+        return __DIR__.'/../../stubs/Fieldset.stub';
     }
 
     /**

--- a/src/Console/MakeGlobalSetCommand.php
+++ b/src/Console/MakeGlobalSetCommand.php
@@ -26,7 +26,7 @@ class MakeGlobalSetCommand extends BaseGeneratorCommand
      */
     protected function getStub()
     {
-        return __DIR__.'/../../stubs/global-set.stub';
+        return __DIR__.'/../../stubs/Global-Set.stub';
     }
 
     /**

--- a/src/Console/MakeTaxonomyCommand.php
+++ b/src/Console/MakeTaxonomyCommand.php
@@ -26,7 +26,7 @@ class MakeTaxonomyCommand extends BaseGeneratorCommand
      */
     protected function getStub()
     {
-        return __DIR__.'/../../stubs/taxonomy.stub';
+        return __DIR__.'/../../stubs/Taxonomy.stub';
     }
 
     /**


### PR DESCRIPTION
Commands didn't work on Linux because Linux has case-sensitive file systems. My guess is that the package was originally developed on MacOS, where FS is not case-sensitive.

This PR fixes the path naming to stub files, and `make' commands work as intended again.