### PR TITLE
Add fields parameter to Grid constructor and initialize fields property

### DIFF
--- a/src/FieldTypes/Grid.php
+++ b/src/FieldTypes/Grid.php
@@ -22,11 +22,15 @@ class Grid extends Field
 
     protected $min_rows;
 
+    protected $fields;
+
     protected $mode = GridModeOption::Table;
 
-    public function __construct(string $handle)
+    public function __construct(string $handle, array $fields = [])
     {
         parent::__construct($handle);
+
+        $this->fields = collect($fields);
     }
 
     public function fieldToArray(): Collection
@@ -38,6 +42,7 @@ class Grid extends Field
             'max_rows' => $this->max_rows,
             'min_rows' => $this->min_rows,
             'mode' => $this->mode->value,
+            'fields' => $this->fieldsToArray(),
         ]);
     }
 

--- a/tests/Unit/Fields/GridTest.php
+++ b/tests/Unit/Fields/GridTest.php
@@ -65,3 +65,11 @@ test('it can render to a array with mode', function () {
 
     expect($field->toArray()['field']['mode'])->toBe(\Tdwesten\StatamicBuilder\Enums\GridModeOption::Table->value);
 });
+
+it('can render to a array with fields', function () {
+    $field = new \Tdwesten\StatamicBuilder\FieldTypes\Grid('grid', [
+        new \Tdwesten\StatamicBuilder\FieldTypes\Text('title'),
+    ]);
+
+    expect($field->toArray()['field']['fields'][0]['field']['type'])->toBe('text');
+});


### PR DESCRIPTION
I noticed the Grid field was not registering the fields array so this is an attempt to fix that.