### PR TITLE
Include fieldsets from config/statamic/builder.php in `Statamic\Facades\Fieldset::all`

### DIFF
--- a/src/Http/Controllers/FieldsetController.php
+++ b/src/Http/Controllers/FieldsetController.php
@@ -2,6 +2,7 @@
 
 namespace Tdwesten\StatamicBuilder\Http\Controllers;
 
+use ReflectionClass;
 use Statamic\Facades\Fieldset as FieldsetFacade;
 use Statamic\Http\Controllers\CP\Fields\FieldsetController as StatamicFieldsetController;
 
@@ -12,10 +13,12 @@ class FieldsetController extends StatamicFieldsetController
         $builderFieldset = FieldsetFacade::findFieldset($fieldset);
 
         if ($builderFieldset) {
+            $reflection = new ReflectionClass($builderFieldset);
+
             return view('statamic-builder::not-editable', [
                 'type' => 'Fieldset',
                 'isLocal' => config('app.env') === 'local' || config('app.env') === 'development',
-                'filePath' => null,
+                'filePath' => $reflection->getFileName(),
             ]);
         }
 

--- a/src/Http/Controllers/FieldsetController.php
+++ b/src/Http/Controllers/FieldsetController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tdwesten\StatamicBuilder\Http\Controllers;
+
+use Statamic\Facades\Fieldset as FieldsetFacade;
+use Statamic\Http\Controllers\CP\Fields\FieldsetController as StatamicFieldsetController;
+
+class FieldsetController extends StatamicFieldsetController
+{
+    public function edit($fieldset)
+    {
+        $builderFieldset = FieldsetFacade::findFieldset($fieldset);
+
+        if ($builderFieldset) {
+            return view('statamic-builder::not-editable', [
+                'type' => 'Fieldset',
+                'isLocal' => config('app.env') === 'local' || config('app.env') === 'development',
+                'filePath' => null,
+            ]);
+        }
+
+        return parent::edit($fieldset);
+    }
+}

--- a/src/Repositories/BlueprintRepository.php
+++ b/src/Repositories/BlueprintRepository.php
@@ -122,6 +122,10 @@ class BlueprintRepository extends StatamicBlueprintRepository
 
             $contents = $blueprint->toArray();
 
+            if (is_string($namespace)) {
+                $namespace = str_replace('/', '.', $namespace);
+            }
+
             return $this->make($handle)
                 ->setHidden(Arr::pull($contents, 'hide'))
                 ->setOrder(Arr::pull($contents, 'order'))

--- a/src/Repositories/FieldsetRepository.php
+++ b/src/Repositories/FieldsetRepository.php
@@ -63,4 +63,14 @@ class FieldsetRepository extends FieldsFieldsetRepository
             }, config('statamic.builder.fieldsets', [])),
         ]);
     }
+
+    public function save(StatamicFieldset $fieldset)
+    {
+        if (FieldsetRepository::findFieldset($fieldset->handle())) {
+            // Fieldsets from statamic-builder should not be saved
+            return;
+        }
+
+        parent::save($fieldset);
+    }
 }

--- a/src/Repositories/FieldsetRepository.php
+++ b/src/Repositories/FieldsetRepository.php
@@ -53,12 +53,13 @@ class FieldsetRepository extends FieldsFieldsetRepository
         return collect([
             ...$this->getStandardFieldsets(),
             ...$this->getNamespacedFieldsets(),
-            ...array_map(function ($f) {
-                $f = new $f;
+            ...array_map(function ($fieldset) {
+                $fieldset = new $fieldset;
+
                 return $this
-                    ->make($f->getSlug())
+                    ->make($fieldset->getSlug())
                     ->initialPath(resource_path('fieldsets'))
-                    ->setContents($f->fieldsetToArray());
+                    ->setContents($fieldset->fieldsetToArray());
             }, config('statamic.builder.fieldsets', [])),
         ]);
     }

--- a/src/Repositories/FieldsetRepository.php
+++ b/src/Repositories/FieldsetRepository.php
@@ -66,7 +66,7 @@ class FieldsetRepository extends FieldsFieldsetRepository
 
     public function save(StatamicFieldset $fieldset)
     {
-        if (FieldsetRepository::findFieldset($fieldset->handle())) {
+        if ($this->findFieldset($fieldset->handle())) {
             // Fieldsets from statamic-builder should not be saved
             return;
         }

--- a/src/Repositories/FieldsetRepository.php
+++ b/src/Repositories/FieldsetRepository.php
@@ -2,6 +2,7 @@
 
 namespace Tdwesten\StatamicBuilder\Repositories;
 
+use Illuminate\Support\Collection;
 use Statamic\Fields\Fieldset as StatamicFieldset;
 use Statamic\Fields\FieldsetRepository as FieldsFieldsetRepository;
 use Tdwesten\StatamicBuilder\Fieldset;
@@ -45,5 +46,20 @@ class FieldsetRepository extends FieldsFieldsetRepository
         }
 
         return new $fieldset;
+    }
+
+    public function all(): Collection
+    {
+        return collect([
+            ...$this->getStandardFieldsets(),
+            ...$this->getNamespacedFieldsets(),
+            ...array_map(function ($f) {
+                $f = new $f;
+                return $this
+                    ->make($f->getSlug())
+                    ->initialPath(resource_path('fieldsets'))
+                    ->setContents($f->fieldsetToArray());
+            }, config('statamic.builder.fieldsets', [])),
+        ]);
     }
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -77,6 +77,13 @@ class ServiceProvider extends AddonServiceProvider
                 $app->make(\Tdwesten\StatamicBuilder\Repositories\GlobalRepository::class)
             );
         });
+
+        $this->app->bind(\Statamic\Http\Controllers\CP\Fields\FieldsetController::class, function ($app) {
+            return new \Tdwesten\StatamicBuilder\Http\Controllers\FieldsetController(
+                $app->make(Request::class),
+                $app->make(\Tdwesten\StatamicBuilder\Repositories\FieldsetRepository::class)
+            );
+        });
     }
 
     protected function bindStores()


### PR DESCRIPTION
Currently, statamic-builder's fieldsets do not show up in the Content Panel's Fieldset index view.

By adding statamic-builder's registered fieldsets (those in `config:statamic.builder.fieldsets`) to the collection returned by `Statamic\Facades\Fieldsets::all`, Statamic's Content Panel is able to see statamic-builder's fieldsets in addition to its own. Great for hybrid setups where you may want to mix programmatic fieldsets with those made in the content panel manually!

I found a bug while implementing this where `StatamicBuilder\BlueprintRepository::in` sets a given Blueprint's namespace to the one provided without sanitizing it to be compatible with Statamic methods, like [this one](https://github.com/statamic/cms/blob/1bb28a16b3e312c47e1723c1019bc77a6582add8/src/Http/Controllers/CP/Fields/FieldsetController.php#L59), by replacing the `/` separator with a `.` separator. So, that's addressed here as well with a str_replace like some of the other methods in the same file.