### PR TITLE
Fix crash when editing taxonomy blueprints

### DIFF
--- a/src/Http/Controllers/CollectionBlueprintsController.php
+++ b/src/Http/Controllers/CollectionBlueprintsController.php
@@ -12,7 +12,7 @@ class CollectionBlueprintsController extends StatamicCollectionBlueprintsControl
 
     public function edit($collection, $blueprint)
     {
-        $blueprint = $collection->entryBlueprint($blueprint);
+        $blueprint = $collection->entryBlueprint($givenBlueprint = $blueprint);
 
         $builderBlueprint = BlueprintRepository::findBlueprint($blueprint->namespace(), $blueprint->handle());
 
@@ -26,6 +26,6 @@ class CollectionBlueprintsController extends StatamicCollectionBlueprintsControl
             ]);
         }
 
-        return parent::edit($collection, $blueprint);
+        return parent::edit($collection, $givenBlueprint);
     }
 }

--- a/src/Http/Controllers/TaxonomyBlueprintsController.php
+++ b/src/Http/Controllers/TaxonomyBlueprintsController.php
@@ -9,7 +9,7 @@ class TaxonomyBlueprintsController extends StatamicTaxonomyBlueprintsController
 {
     public function edit($taxonomy, $blueprint)
     {
-        $blueprint = $taxonomy->termBlueprint($blueprint);
+        $blueprint = $taxonomy->termBlueprint($givenBlueprint = $blueprint);
 
         $builderBlueprint = BlueprintRepository::findBlueprint($blueprint->namespace(), $blueprint->handle());
 
@@ -23,6 +23,6 @@ class TaxonomyBlueprintsController extends StatamicTaxonomyBlueprintsController
             ]);
         }
 
-        return parent::edit($taxonomy, $blueprint);
+        return parent::edit($taxonomy, $givenBlueprint);
     }
 }


### PR DESCRIPTION
Hi!

I've noticed Statamic Builder causes a crash when trying to edit Taxonomy Blueprints.

In the TaxonomyBlueprintsController provided by Statamic-Builder, the blueprint parameter passed into `::edit` gets overridden and then potentially passed into `parent::edit` despite the malformed parameter:
```php
// $blueprint is the string handle for the blueprint
public function edit($taxonomy, $blueprint)
{
    $blueprint = $taxonomy->termBlueprint($blueprint);
    // ...
    // parent::edit gets an object instead of the string passed into this method
    return parent::edit($taxonomy, $blueprint);
```

This results in the `parent::edit` method calling `$taxonomy->termBlueprint` again except with an object instead of the expected string. Here's the resulting error and stack trace:
```
[2025-03-15 01:43:13] local.ERROR: array_key_exists(): Argument #1 ($key) must be a valid array offset type {"exception":"[object] (TypeError(code: 0): array_key_exists(): Argument #1 ($key) must be a valid array offset type at ...path-to-app/vendor/laravel/framework/src/Illuminate/Collections/Collection.php:468)
[stacktrace]
#0 ...path-to-app/vendor/laravel/framework/src/Illuminate/Collections/Collection.php(468): array_key_exists()
#1 ...path-to-app/vendor/statamic/cms/src/Taxonomies/Taxonomy.php(151): Illuminate\\Support\\Collection->get()
#2 ...path-to-app/vendor/statamic/cms/src/Taxonomies/Taxonomy.php(125): Statamic\\Taxonomies\\Taxonomy->getBaseTermBlueprint()
#3 ...path-to-app/vendor/statamic/cms/src/Http/Controllers/CP/Taxonomies/TaxonomyBlueprintsController.php(39): Statamic\\Taxonomies\\Taxonomy->termBlueprint()
#4 ...path-to-app/vendor/tdwesten/statamic-builder/src/Http/Controllers/TaxonomyBlueprintsController.php(26): Statamic\\Http\\Controllers\\CP\\Taxonomies\\TaxonomyBlueprintsController->edit()
#5 ...path-to-app/vendor/laravel/framework/src/Illuminate/Routing/Controller.php(54): Tdwesten\\StatamicBuilder\\Http\\Controllers\\TaxonomyBlueprintsController->edit()
```

To fix this, I've stored the original blueprint handle passed into the method in a temporary variable. That temporary variable then gets passed to `parent::edit` instead of the Blueprint object:
```php
$blueprint = $taxonomy->termBlueprint($givenBlueprint = $blueprint);
// ...
return parent::edit($taxonomy, $givenBlueprint);
```

This bug is technically present in the CollectionBlueprintsController too. However, Statamic uses Blink to get the result for the `$collection->entryBlueprint` call. So, when the parent calls entryBlueprint again (after the first call being by Statamic-Builder's implementation), Blink returns the first result so no error gets thrown. I've implemented a similar patch to the CollectionBlueprintsController too, though.

Let me know if there's anything else I can do to help get this merged! Thanks!