### PR TITLE
fix: preserve fields order when flattening in FieldParser

### DIFF
--- a/src/Helpers/FieldParser.php
+++ b/src/Helpers/FieldParser.php
@@ -14,12 +14,16 @@ class FieldParser
     {
         $items = collect($items);
 
-        return $items->map(function ($field) {
-            if ($field instanceof Fieldset) {
-                return $field->getFields();
-            }
+        $items
+            ->map(function ($item) {
+                if ($item instanceof Fieldset) {
+                    return $item;
+                }
 
-            return $field;
-        })->flatten(1);
+                return [$item];
+            })
+            ->flatten();
+
+        return $items;
     }
 }

--- a/src/Helpers/FieldParser.php
+++ b/src/Helpers/FieldParser.php
@@ -4,7 +4,6 @@ namespace Tdwesten\StatamicBuilder\Helpers;
 
 use Illuminate\Support\Collection;
 use Tdwesten\StatamicBuilder\Fieldset;
-use Tdwesten\StatamicBuilder\FieldTypes\Field;
 
 class FieldParser
 {

--- a/src/Helpers/FieldParser.php
+++ b/src/Helpers/FieldParser.php
@@ -15,16 +15,12 @@ class FieldParser
     {
         $items = collect($items);
 
-        $fieldsets = $items->filter(function ($field) {
-            return $field instanceof Fieldset;
-        })->flatten();
+        return $items->map(function ($field) {
+            if ($field instanceof Fieldset) {
+                return $field->getFields();
+            }
 
-        $fields = $items->filter(function ($field) {
-            return $field instanceof Field;
-        });
-
-        $items = collect($fieldsets)->merge($fields);
-
-        return $items;
+            return $field;
+        })->flatten(1);
     }
 }

--- a/tests/Unit/FieldParserTest.php
+++ b/tests/Unit/FieldParserTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Unit;
 
-use Tdwesten\StatamicBuilder\Helpers\FieldParser;
 use Tdwesten\StatamicBuilder\FieldTypes\Text;
+use Tdwesten\StatamicBuilder\Helpers\FieldParser;
 use Tests\Helpers\TestFieldset;
 
 test('it preserves field order when flattening mixed fields', function () {

--- a/tests/Unit/FieldParserTest.php
+++ b/tests/Unit/FieldParserTest.php
@@ -20,8 +20,6 @@ test('it preserves field order when flattening mixed fields', function () {
     $fields = FieldParser::parseMixedFieldsToFlatCollection($mixedFields);
 
     expect($fields[0]->toArray()['handle'])->toBe('standalone_field_1');
-    expect($fields[1]->toArray()['handle'])->toBe('test_fieldset.title');
-    expect($fields[2]->toArray()['handle'])->toBe('test_fieldset.description');
-    expect($fields[3]->toArray()['handle'])->toBe('test_fieldset.link');
-    expect($fields[4]->toArray()['handle'])->toBe('standalone_field_2');
+    expect($fields[1]->toArray()['import'])->toBe('test_fieldset');
+    expect($fields[2]->toArray()['handle'])->toBe('standalone_field_2');
 });

--- a/tests/Unit/FieldParserTest.php
+++ b/tests/Unit/FieldParserTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tdwesten\StatamicBuilder\Helpers\FieldParser;
+use Tdwesten\StatamicBuilder\FieldTypes\Text;
+use Tests\Helpers\TestFieldset;
+
+test('it preserves field order when flattening mixed fields', function () {
+    $fieldset = new TestFieldset('test_fieldset');
+    $standaloneField1 = new Text('standalone_field_1');
+    $standaloneField2 = new Text('standalone_field_2');
+
+    $mixedFields = [
+        $standaloneField1,
+        $fieldset,
+        $standaloneField2,
+    ];
+
+    $fields = FieldParser::parseMixedFieldsToFlatCollection($mixedFields);
+
+    expect($fields[0]->toArray()['handle'])->toBe('standalone_field_1');
+    expect($fields[1]->toArray()['handle'])->toBe('test_fieldset.title');
+    expect($fields[2]->toArray()['handle'])->toBe('test_fieldset.description');
+    expect($fields[3]->toArray()['handle'])->toBe('test_fieldset.link');
+    expect($fields[4]->toArray()['handle'])->toBe('standalone_field_2');
+});


### PR DESCRIPTION
closes #51 