### PR TITLE
Fix: Global Repository Can't Return Null

### DIFF
--- a/src/Repositories/GlobalRepository.php
+++ b/src/Repositories/GlobalRepository.php
@@ -39,11 +39,7 @@ class GlobalRepository extends StatamicGlobalRepository
             return (new $global)->register();
         }
 
-        $r = parent::find($id);
-
-        if ($r) {
-            return $r;
-        }
+        return parent::find($id);
     }
 
     private function initializeGlobals()

--- a/tests/Unit/GlobalRepositoryTest.php
+++ b/tests/Unit/GlobalRepositoryTest.php
@@ -1,0 +1,15 @@
+<?php
+
+use Statamic\Facades\GlobalSet;
+use Tests\TestCase;
+
+pest()->extend(TestCase::class);
+test('::find does not throw when no result is found', function (): void {
+    GlobalSet::find('id-that-does-not-exist');
+})->throwsNoExceptions();
+
+test('::find returns null for nonexistent handles', function (): void {
+    $nullset = GlobalSet::find('id-that-does-not-exist');
+
+    expect($nullset)->toBeNull();
+});


### PR DESCRIPTION
I noticed Statamic Builder's `GlobalRepository::find` method is unable to return null from `parent::find`. There's a check that `parent::find`'s result isn't falsey, but returning `null` is proper behavior of `GlobalRepository::find`. If the result is falsey `::find` does not return in Statamic Builder's implementation, which is a violation of its return type `?GlobalSet`, causing an error to be thrown.

This pull request removes the falsey check and returns the `parent::find` result no questions asked. Test included (checkout 3ef6e1d to get the test to fail).