### PR TITLE
fix: limit flattening depth

### DIFF
--- a/src/Helpers/FieldParser.php
+++ b/src/Helpers/FieldParser.php
@@ -22,7 +22,7 @@ class FieldParser
 
                 return [$item];
             })
-            ->flatten();
+            ->flatten(1);
 
         return $items;
     }


### PR DESCRIPTION
This PR addresses a side effect introduced by the fix in #52, which resolved issue #51 related to preserving the original order of fields when flattening mixed fieldsets and fields.

In the current implementation, `flatten()` method is used without a depth parameter, which unintentionally flattens too deeply. This causes issues during augmentation, especially when dealing with complex nested fields configurations.

What’s changed:
- Updated the `flatten()` method to use a depth of `1`, ensuring only the immediate level is flattened.
- This preserves field order correctly while avoiding issues with over-flattened data structures.

