### PR TITLE
fix: Entries passing queryscopes value to Datastructure

### DIFF
--- a/src/FieldTypes/Entries.php
+++ b/src/FieldTypes/Entries.php
@@ -35,6 +35,7 @@ class Entries extends Field
             'mode' => $this->mode->value,
             'collections' => $this->collections,
             'search_index' => $this->searchIndex,
+            'query_scopes' => $this->queryScopes,
         ]);
     }
 


### PR DESCRIPTION
The Entries Fieldtype uses the QueryScopes trait but is not passing the value to the Statamic Datastructure.  This PR fixes this.