### PR TITLE
fix: ability to toggle create ability on Entries Fieldtype

### DIFF
--- a/src/FieldTypes/Entries.php
+++ b/src/FieldTypes/Entries.php
@@ -52,4 +52,11 @@ class Entries extends Field
 
         return $this;
     }
+
+    public function create(bool $create = true)
+    {
+        $this->create = $create;
+
+        return $this;
+    }
 }


### PR DESCRIPTION
The Entries Fieldtype is missing the option to toggle the create ability. This PR fixes this in line with how it is handled in the Terms Fieldtype.