### PR TITLE
Foreign fieldsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,45 @@ This addon allows you to create blueprints and fieldsets in a fluent way. This m
        }
    }
    ```
+### Working with foreign fieldset
+When working with a mixed Codebase or while using other Statamic plugins you can use their provided Fieldsets with the `ForeignFieldset` and `ForeignField` class which implement similar to the Statamic Standard Import.
+
+```php
+   <?php
+
+   namespace App\Blueprints;
+
+   use Tdwesten\StatamicBuilder\Blueprint;
+   use Tdwesten\StatamicBuilder\FieldTypes\ForeignField;
+   use Tdwesten\StatamicBuilder\FieldTypes\ForeignFieldset;
+
+   class PageBlueprint extends Blueprint
+   {
+       public $title = 'Page';
+
+       public $handle = 'page';
+
+       public $hidden = false;
+
+       public function registerTabs(): Array
+       {
+           return [
+               Tab::make('General', [
+                   Section::make('General', [
+                        ForeignFieldset::make('statamic-peak-seo::seo_basic')
+                            ->prefix('myseo_')
+                        ForeignField::make('mytext','foreign_fields.bard')
+                            ->config([
+                                'width'=>'25',
+                                'display' => "My bard Field"
+                                'validate' => 'required|string|max:3',
+                            ])
+                   ]),
+               ]),
+           ];
+       }
+   }
+```
 
 ### Supported Fieldtypes
 

--- a/src/FieldTypes/ForeignField.php
+++ b/src/FieldTypes/ForeignField.php
@@ -6,7 +6,6 @@ namespace Tdwesten\StatamicBuilder\FieldTypes;
 
 class ForeignField
 {
-
     protected ?array $config;
 
     public function __construct(protected string $handle, protected string $field) {}
@@ -15,6 +14,7 @@ class ForeignField
     {
         return new static($handle, $field);
     }
+
     public function toArray(): array
     {
         return [

--- a/src/FieldTypes/ForeignField.php
+++ b/src/FieldTypes/ForeignField.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tdwesten\StatamicBuilder\FieldTypes;
+
+class ForeignField
+{
+
+    protected ?array $config;
+
+    public function __construct(protected string $handle, protected string $field) {}
+
+    public static function make(string $handle, string $field): self
+    {
+        return new static($handle, $field);
+    }
+    public function toArray(): array
+    {
+        return [
+            'handle' => $this->handle,
+            'field' => $this->field,
+            'config' => $this->config ?? [],
+        ];
+    }
+
+    public function field(string $field): self
+    {
+        $this->field = $field;
+
+        return $this;
+    }
+
+    public function config(?array $config): self
+    {
+        $this->config = $config;
+
+        return $this;
+    }
+}

--- a/src/FieldTypes/ForeignFieldset.php
+++ b/src/FieldTypes/ForeignFieldset.php
@@ -12,7 +12,7 @@ class ForeignFieldset
 
     protected ?string $prefix;
 
-    public function __construct(protected string $handle){}
+    public function __construct(protected string $handle) {}
 
     public static function make(string $handle): self
     {

--- a/src/FieldTypes/ForeignFieldset.php
+++ b/src/FieldTypes/ForeignFieldset.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tdwesten\StatamicBuilder\FieldTypes;
+
+use Tdwesten\StatamicBuilder\Contracts\Makeble;
+
+class ForeignFieldset
+{
+    use Makeble;
+
+    protected ?string $prefix;
+
+    public function __construct(protected string $handle){}
+
+    public static function make(string $handle): self
+    {
+        return new static($handle);
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'import' => $this->handle,
+            'prefix' => $this->prefix ?? null,
+        ];
+    }
+
+    public function prefix(string $prefix): self
+    {
+        $this->prefix = $prefix;
+
+        return $this;
+    }
+}


### PR DESCRIPTION
Goes with https://github.com/tdwesten/statamic-builder/issues/64

Until the full Importer/Codegenerator works this seems to be a good interims solution I'm already using. It goes very well in a mixed codebase and imports local as well as plugin fieldsets alike as long as you follow the statmic naming conventions.