### PR TITLE
Add collapsible support to blueprint Sections

### DIFF
--- a/src/FieldTypes/Section.php
+++ b/src/FieldTypes/Section.php
@@ -8,7 +8,11 @@ class Section extends Field
 
     protected $displayName;
 
-    public function __construct($displayName, $fields = [])
+    protected ?bool $collapsible = null;
+
+    protected ?bool $collapsed = null;
+
+    public function __construct(string $displayName, array $fields = [])
     {
         $this->displayName = $displayName;
         $this->fields = collect($fields);
@@ -19,12 +23,31 @@ class Section extends Field
         return new static($displayName, $fields);
     }
 
-    public function toArray()
+    public function collapsible(bool $collapsible = true): static
     {
-        return [
+        $this->collapsible = $collapsible;
+
+        return $this;
+    }
+
+    public function collapsed(bool $collapsed = true): static
+    {
+        $this->collapsed = $collapsed;
+
+        return $this;
+    }
+
+    public function toArray(): array
+    {
+        return collect([
             'display' => $this->displayName,
+            'instructions' => $this->instructions,
+            'collapsible' => $this->collapsible,
+            'collapsed' => $this->collapsible === true ? ($this->collapsed ?? false) : null,
             'fields' => $this->fieldsToArray(),
-        ];
+        ])->filter(function ($item) {
+            return ! in_array($item, [null, ''], true);
+        })->toArray();
     }
 
     public function fieldsToArray(): array

--- a/tests/Unit/Fields/SectionTest.php
+++ b/tests/Unit/Fields/SectionTest.php
@@ -13,3 +13,38 @@ test('Section can be rendered', function (): void {
     expect($array['display'])->toBe('General');
     expect($array['fields'][0]['handle'])->toBe('title');
 });
+
+test('Section can render instructions', function (): void {
+    $section = Section::make('General', [
+        Text::make('title')->displayName('Title'),
+    ])->instructions('Helpful section copy');
+
+    expect($section->toArray()['instructions'])->toBe('Helpful section copy');
+});
+
+test('Section can be collapsible', function (): void {
+    $section = Section::make('General', [
+        Text::make('title')->displayName('Title'),
+    ])->collapsible();
+
+    expect($section->toArray()['collapsible'])->toBeTrue();
+    expect($section->toArray()['collapsed'])->toBeFalse();
+});
+
+test('Section can be collapsed when collapsible', function (): void {
+    $section = Section::make('General', [
+        Text::make('title')->displayName('Title'),
+    ])->collapsible()->collapsed();
+
+    expect($section->toArray()['collapsible'])->toBeTrue();
+    expect($section->toArray()['collapsed'])->toBeTrue();
+});
+
+test('Section does not render collapsed without collapsible', function (): void {
+    $section = Section::make('General', [
+        Text::make('title')->displayName('Title'),
+    ])->collapsed();
+
+    expect($section->toArray())->not->toHaveKey('collapsed');
+    expect($section->toArray())->not->toHaveKey('collapsible');
+});


### PR DESCRIPTION
## Summary
Adds support for collapsible blueprint sections (https://github.com/statamic/cms/pull/11995).

Main changes:
- adds `collapsible`
- adds `collapsed`

As a smaller follow-up in the same area, `Section` now also serializes `instructions` correctly.

## Notes
`collapsed` is only included when the section is marked as collapsible.
Existing sections keep their previous output unless the new section state is used.

## Testing
Added section tests covering:
- instructions serialization
- collapsible sections
- collapsed sections
- guarding `collapsed` when `collapsible` is not enabled

All added and related tests pass.