### PR TITLE
fix: remove hardcoded version from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,6 @@
 {
   "name": "tdwesten/statamic-builder",
   "description": "A fluent blueprint and fieldset builder for Statamic.",
-  "version": "v3.0.0",
   "license": "MIT",
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
## Problem

The `composer.json` file had a hardcoded `"version": "v3.0.0"` field.
When Packagist crawls a git tag (e.g. v3.0.1), it reads `composer.json`
at that tag. If the declared version doesn't match the tag name, Packagist
either skips the tag or registers it under the wrong version — which is why
releases v3.0.1–v3.0.5 don't appear on Packagist.

## Fix

Removed the `"version"` field. Composer/Packagist automatically derives
the version from the git tag name — this field should never be hardcoded
in a library's composer.json.

## Impact

- Releases v3.0.1–v3.0.5 (and all future tags) will be correctly indexed
  by Packagist and installable via Composer.
- No functional code changes.