### PR TITLE
Laravel 13 compatibility

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,9 +33,14 @@ jobs:
       fail-fast: false
       matrix:
         php: [ 8.3, 8.4, 8.5 ]
-        laravel: [ 12.* ]
+        laravel: [ 12.*, 13.* ]
         statamic: [ 6.* ]
         stability: [ prefer-stable ]
+        include:
+          - laravel: 12.*
+            testbench: ^10.0
+          - laravel: 13.*
+            testbench: ^11.0
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - S${{ matrix.statamic }} - ${{ matrix.stability }}
 
@@ -52,7 +57,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "statamic/cms:${{ matrix.statamic }}" "orchestra/testbench:^10.0" --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}" "statamic/cms:${{ matrix.statamic }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction -W
 
       - name: Execute tests

--- a/composer.json
+++ b/composer.json
@@ -33,14 +33,14 @@
   },
   "require": {
     "php": "^8.3",
-    "illuminate/support": "^12.0",
-    "laravel/framework": "^12.0",
+    "illuminate/support": "^12.0|^13.0",
+    "laravel/framework": "^12.0|^13.0",
     "statamic/cms": "^6.0"
   },
   "require-dev": {
     "pestphp/pest": "^4.1",
     "laravel/pint": "^1.2",
-    "orchestra/testbench": "^10.0",
+    "orchestra/testbench": "^10.0|^11.0",
     "pestphp/pest-plugin-laravel": "^4.0",
     "statamic/eloquent-driver": "dev-master",
     "rector/rector": "^2.0"


### PR DESCRIPTION
Adds compatibility with Laravel 13.

- Expand `laravel/framework` and `illuminate/support` constraints to `^12.0|^13.0`
- Expand `orchestra/testbench` dev dependency to `^10.0|^11.0`
- Add Laravel 13.* to CI test matrix with the correct testbench version (`^11.0`)